### PR TITLE
Update homebrew instrucutions in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Via [homebrew](http://brew.sh):
 
 	$ brew update
 	$ brew tap samdmarshall/formulae
-	$ brew install samdmarshall/formulae/pyconfig --head
+	$ brew install samdmarshall/formulae/pyconfig --HEAD
 
 Alternatively you can clone the repo and run the `setup.py` file to install.
 


### PR DESCRIPTION
When running the `brew install` instruction from the Installation section the following message is given:

`Error: Specify `--HEAD` in uppercase to build from trunk`

This commit corrects the option to the capitalized version