### PR TITLE
Adding scheme name test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pyconfig.egg-info/
 *.xcconfig
 *.pyc
 __pycache__/
-htmlcov
+htmlcov/
 .eggs
 
 # make sure to include the static test output data

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,33 @@
+# Copyright (c) 2016, Samantha Marshall (http://pewpewthespells.com)
+# All rights reserved.
+#
+# https://github.com/samdmarshall/pyconfig
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this 
+# list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of Samantha Marshall nor the names of its contributors may 
+# be used to endorse or promote products derived from this software without 
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
 source 'https://rubygems.org'
 
 gem 'danger'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,34 @@
+# Copyright (c) 2016, Samantha Marshall (http://pewpewthespells.com)
+# All rights reserved.
+#
+# https://github.com/samdmarshall/pyconfig
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this 
+# list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of Samantha Marshall nor the names of its contributors may 
+# be used to endorse or promote products derived from this software without 
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
 INSTALLED_FILES_RECORD := ./installed_files.txt
-DANGER_GITHUB_API_TOKEN := 5e94e727bcc91e7ff681e2995af2a0c4961404de
 
 PYTHON2_CMD := python
 PYTHON3_CMD := python3
@@ -15,11 +44,15 @@ COVERAGE := $(shell command -v $(COVERAGE_CMD) 2> /dev/null)
 DANGER := $(shell command -v $(DANGER_CMD) 2> /dev/null)
 GEM := $(shell command -v $(GEM_CMD) 2> /dev/null)
 
+# --- 
+
 install-tools:
 	@echo "Installing git hooks..."
 	@python ./tools/hooks-config.py
 	@echo "Installing danger via ruby-gems..."
 	@$(GEM) install danger --user
+
+# --- 
 
 check: 
 	@type $(PYTHON2_CMD) >/dev/null 2>&1 || echo "Please install Python 2"
@@ -29,6 +62,8 @@ check:
 	@type $(DANGER_CMD) >/dev/null 2>&1 || echo "Please install danger"
 	@type $(GEM_CMD) >/dev/null 2>&1 || echo "Please install ruby-gems"
 
+# --- 
+
 clean: check
 	@echo "Removing existing installation..."
 	@touch $(INSTALLED_FILES_RECORD)
@@ -37,19 +72,23 @@ clean: check
 	@rm -rdf ./build
 	@rm -rdf ./dist
 	@rm -rdf ./.tox
-	@rm -rdf ./tests/__pycache__
 	@rm -rdf .coverage
 	@rm -rdf ./htmlcov
 	@find . -name "*.pyc" -print0 | xargs -0 rm -rdf
 	@find . -name "__pycache__" -type d -print0 | xargs -0 rm -rdf
 	@find ./tests -name "*.xcconfig" -and -not -name "*_output.xcconfig" -print0 | xargs -0 rm -rdf
 	
+# --- 
 	
 build2: clean
 	$(PYTHON2) ./setup.py install --user --record $(INSTALLED_FILES_RECORD)
 	
+# --- 
+	
 build3: clean
 	$(PYTHON3) ./setup.py install --record $(INSTALLED_FILES_RECORD)
+
+# --- 
 
 test: check
 	$(TOX)
@@ -59,12 +98,16 @@ ifeq ($(CIRCLE_BRANCH),develop)
 endif
 endif
 
+# --- 
+
 report: check
 	$(COVERAGE) report
 	$(COVERAGE) html
 ifdef CIRCLE_ARTIFACTS
 	cp -r ./htmlcov $(CIRCLE_ARTIFACTS)
 endif 
+
+# --- 
 
 danger: check
 ifdef CIRCLE_BUILD_NUM
@@ -73,5 +116,6 @@ else
 	$(DANGER) local --verbose
 endif
 	
-	
+# --- 
+
 ci: test report danger

--- a/pyconfig/version_info.py
+++ b/pyconfig/version_info.py
@@ -1,2 +1,2 @@
 remote_origin = 'git@github.com:samdmarshall/pyconfig.git'
-commit_hash = '2f3d087'
+commit_hash = '56be4a0'

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,33 @@
+# Copyright (c) 2016, Samantha Marshall (http://pewpewthespells.com)
+# All rights reserved.
+#
+# https://github.com/samdmarshall/pyconfig
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this 
+# list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of Samantha Marshall nor the names of its contributors may 
+# be used to endorse or promote products derived from this software without 
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
 module_dependencies = []
 module_version = '1.0.2'
 try:
@@ -34,7 +64,9 @@ try:
             'pyconfig/Helpers',
             'pyconfig/Keyword',
         ],
-        entry_points = { 'console_scripts': ['pyconfig = pyconfig:main'] },
+        entry_points = { 
+            'console_scripts': [ 'pyconfig = pyconfig:main' ] 
+        },
         test_suite = 'tests.pyconfig_test',
         zip_safe = False,
         **install_requires_dict

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,29 @@
-#!/usr/bin/python
-
+# Copyright (c) 2016, Samantha Marshall (http://pewpewthespells.com)
+# All rights reserved.
+#
+# https://github.com/samdmarshall/pyconfig
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this 
+# list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of Samantha Marshall nor the names of its contributors may 
+# be used to endorse or promote products derived from this software without 
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+# OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/pyconfig_test.py
+++ b/tests/pyconfig_test.py
@@ -1,3 +1,33 @@
+# Copyright (c) 2016, Samantha Marshall (http://pewpewthespells.com)
+# All rights reserved.
+#
+# https://github.com/samdmarshall/pyconfig
+# 
+# Redistribution and use in source and binary forms, with or without modification, 
+# are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this 
+# list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, 
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of Samantha Marshall nor the names of its contributors may 
+# be used to endorse or promote products derived from this software without 
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import os
 import sys
 import string
@@ -6,11 +36,13 @@ import pyconfig
 
 test_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tests')
 
-def LoadTestDirectoryAndTestWithName(test, test_pyconfig_path_sub, test_file_name):
+def LoadTestDirectoryAndTestWithName(test, test_pyconfig_path_sub, test_file_name, additional_flags=[]):
     test_pyconfig_path = os.path.join(test_directory, test_pyconfig_path_sub)
     test_generated_output = os.path.join(test_pyconfig_path, test_file_name+'.xcconfig')
     test_expected_output = os.path.join(test_pyconfig_path, test_file_name+'_output.xcconfig')
-    pyconfig.main(['-q', test_pyconfig_path])
+    args = ['-q', test_pyconfig_path]
+    args.extend(additional_flags)
+    pyconfig.main(args)
     with open(test_generated_output, 'r') as generated, open(test_expected_output, 'r') as expected:
         generated_lines = generated.readlines()[2:]
         expected_lines = expected.readlines()[2:]
@@ -50,6 +82,9 @@ class pyconfigTestCases(unittest.TestCase):
         
     def test_variable_substitution_without_use(self):
         LoadTestDirectoryAndTestWithName(self, 'variable substitution/without-use', 'test')
+    
+    def test_flags_scheme_name(self):
+        LoadTestDirectoryAndTestWithName(self, 'flags/scheme name', 'test', ['--scheme', 'MyAppDebug'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests/flags/scheme name/test.pyconfig
+++ b/tests/tests/flags/scheme name/test.pyconfig
@@ -1,0 +1,11 @@
+setting PRODUCT_NAME use SCHEME_NAME {
+	for MyAppDev {
+		Developer Build
+	}
+	for MyAppEnterprise {
+		Enterprise Build
+	}
+	for MyAppProduction {
+		App Store Build
+	}
+}

--- a/tests/tests/flags/scheme name/test_output.xcconfig
+++ b/tests/tests/flags/scheme name/test_output.xcconfig
@@ -1,0 +1,7 @@
+// TEST DATA
+// TEST DATA
+SCHEME_NAME = MyAppDebug
+PRODUCT_NAME_MyAppDev = Developer Build
+PRODUCT_NAME_MyAppEnterprise = Enterprise Build
+PRODUCT_NAME_MyAppProduction = App Store Build
+PRODUCT_NAME = $(PRODUCT_NAME_$(SCHEME_NAME))


### PR DESCRIPTION
Adding unit test for the logic of defining a scheme name as an additional variable in the generated xcconfig file.

Fixes:
#29
