### PR TITLE
moving dependency installation away from circleci and into makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,15 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Variables
+
+# path to installation record that gets written when performing:
+# - make build2
+# - make build3
+
 INSTALLED_FILES_RECORD := ./installed_files.txt
+
+# names of the executables that are used as a part of this project
 
 PYTHON2_CMD := python
 PYTHON3_CMD := python3
@@ -36,6 +44,21 @@ TOX_CMD := tox
 COVERAGE_CMD := coverage
 DANGER_CMD := danger
 GEM_CMD := gem
+FIND_CMD := find
+RM_CMD := rm
+WHICH_CMD := which
+XARGS_CMD := xargs
+PRINTF_CMD := printf
+TOUCH_CMD := touch
+CP_CMD := cp
+CAT_CMD := cat
+PIP_CMD := pip
+CCTREPORTER_CMD := codeclimate-test-reporter
+
+PYPARSING := pyparsing
+TOX_PYENV := tox-pyenv
+
+# invoke the specific executable command
 
 PYTHON2 := $(shell command -v $(PYTHON2_CMD) 2> /dev/null)
 PYTHON3 := $(shell command -v $(PYTHON3_CMD) 2> /dev/null)
@@ -43,40 +66,88 @@ TOX := $(shell command -v $(TOX_CMD) 2> /dev/null)
 COVERAGE := $(shell command -v $(COVERAGE_CMD) 2> /dev/null)
 DANGER := $(shell command -v $(DANGER_CMD) 2> /dev/null)
 GEM := $(shell command -v $(GEM_CMD) 2> /dev/null)
+FIND := $(shell command -v $(FIND_CMD) 2> /dev/null)
+RM := $(shell command -v $(RM_CMD) 2> /dev/null)
+WHICH := $(shell command -v $(WHICH_CMD) 2> /dev/null)
+XARGS := $(shell command -v $(XARGS_CMD) 2> /dev/null)
+PRINTF := $(shell command -v $(PRINTF_CMD) 2> /dev/null)
+TOUCH := $(shell command -v $(TOUCH_CMD) 2> /dev/null)
+CP := $(shell command -v $(CP_CMD) 2> /dev/null)
+CAT := $(shell command -v $(CAT_CMD) 2> /dev/null)
+PIP := $(shell command -v $(PIP_CMD) 2> /dev/null)
+CCTREPORTER := $(shell command -v $(CCTREPORTER_CMD) 2> /dev/null)
+
+# Targets
 
 # --- 
 
-install-tools:
-	@echo "Installing git hooks..."
-	@python ./tools/hooks-config.py
-	@echo "Installing danger via ruby-gems..."
-	@$(GEM) install danger --user
+checkfor = @$(PRINTF) "Checking for $1..."; \
+if [ -z `$(WHICH) $1` ]; then \
+$(PRINTF) " no\n"; \
+exit 1;\
+else \
+$(PRINTF) " yes\n"; \
+fi
+
+check:
+	$(call checkfor,$(WHICH_CMD))
+	$(call checkfor,$(CAT_CMD))
+	$(call checkfor,$(CP_CMD))
+	$(call checkfor,$(TOUCH_CMD))
+	$(call checkfor,$(FIND_CMD))
+	$(call checkfor,$(XARGS_CMD))
+	$(call checkfor,$(RM_CMD))
+	$(call checkfor,$(PYTHON2_CMD))
+	$(call checkfor,$(PYTHON3_CMD))
+	$(call checkfor,$(PIP_CMD))
+	$(call checkfor,$(TOX_CMD))
+	$(call checkfor,$(COVERAGE_CMD))
+	$(call checkfor,$(GEM_CMD))
+	$(call checkfor,$(DANGER_CMD))
+	@echo "============================"
 
 # --- 
 
-check: 
-	@type $(PYTHON2_CMD) >/dev/null 2>&1 || echo "Please install Python 2"
-	@type $(PYTHON3_CMD) >/dev/null 2>&1 || echo "Please install Python 3"
-	@type $(TOX_CMD) >/dev/null 2>&1 || echo "Please install tox"
-	@type $(COVERAGE_CMD) >/dev/null 2>&1 || echo "Please install coverage"
-	@type $(DANGER_CMD) >/dev/null 2>&1 || echo "Please install danger"
-	@type $(GEM_CMD) >/dev/null 2>&1 || echo "Please install ruby-gems"
+pipinstall = @pip install $1 --user
+geminstall = @gem install $1 --user
+
+install-deps: 
+	$(call checkfor,$(PYTHON2_CMD))
+	$(call checkfor,$(PIP_CMD))
+	$(call pipinstall,$(COVERAGE_CMD))
+	$(call pipinstall,$(TOX_CMD))
+	$(call pipinstall,$(PYPARSING))
+	$(call pipinstall,$(TOX_PYENV))
+	$(call pipinstall,$(CCTREPORTER_CMD))
+	$(call checkfor,$(GEM_CMD))
+	$(call geminstall,$(DANGER_CMD))
 
 # --- 
 
+# this is for installing any tools that we don't already have
+install-tools: check
+	@$(PRINTF) "Installing git hooks..."
+	@$(PYTHON) ./tools/hooks-config.py
+	@$(PRINTF) " done!\n"
+
+# --- 
+
+removeall=$(RM) -rdf
+cleanlocation = @$(FIND) $1 $2 -print0 | $(XARGS) -0 $(removeall)
 clean: check
-	@echo "Removing existing installation..."
-	@touch $(INSTALLED_FILES_RECORD)
-	@cat $(INSTALLED_FILES_RECORD) | xargs rm -rf
-	@rm -rdf ./pyconfig.egg-info
-	@rm -rdf ./build
-	@rm -rdf ./dist
-	@rm -rdf ./.tox
-	@rm -rdf .coverage
-	@rm -rdf ./htmlcov
-	@find . -name "*.pyc" -print0 | xargs -0 rm -rdf
-	@find . -name "__pycache__" -type d -print0 | xargs -0 rm -rdf
-	@find ./tests -name "*.xcconfig" -and -not -name "*_output.xcconfig" -print0 | xargs -0 rm -rdf
+	@$(PRINTF) "Removing existing installation...\n"
+	@$(TOUCH) $(INSTALLED_FILES_RECORD)
+	@$(CAT) $(INSTALLED_FILES_RECORD) | $(XARGS) $(removeall)
+	@$(removeall) ./pyconfig.egg-info
+	@$(removeall) ./build
+	@$(removeall) ./dist
+	@$(removeall) ./.tox
+	@$(removeall) .coverage
+	@$(removeall) ./htmlcov
+	$(call cleanlocation, ., -name "*.pyc")
+	$(call cleanlocation, ., -name "__pycache__" -type d)
+	$(call cleanlocation, ./tests, -name "*.xcconfig" -and -not -name "*_output.xcconfig")
+	@echo "============================"
 	
 # --- 
 	
@@ -94,7 +165,7 @@ test: check
 	$(TOX)
 ifdef CIRCLE_BRANCH
 ifeq ($(CIRCLE_BRANCH),develop)
-	codeclimate-test-reporter --token $(value CIRCLECI_CODECLIMATE_TOKEN)
+	$(CCTREPORTER) --token $(value CIRCLECI_CODECLIMATE_TOKEN)
 endif
 endif
 
@@ -104,7 +175,7 @@ report: check
 	$(COVERAGE) report
 	$(COVERAGE) html
 ifdef CIRCLE_ARTIFACTS
-	cp -r ./htmlcov $(CIRCLE_ARTIFACTS)
+	$(CP) -r ./htmlcov $(CIRCLE_ARTIFACTS)
 endif 
 
 # --- 

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ CP_CMD := cp
 CAT_CMD := cat
 PIP_CMD := pip
 CCTREPORTER_CMD := codeclimate-test-reporter
+UNAME_CMD := uname
 
 PYPARSING := pyparsing
 TOX_PYENV := tox-pyenv
@@ -76,6 +77,14 @@ CP := $(shell command -v $(CP_CMD) 2> /dev/null)
 CAT := $(shell command -v $(CAT_CMD) 2> /dev/null)
 PIP := $(shell command -v $(PIP_CMD) 2> /dev/null)
 CCTREPORTER := $(shell command -v $(CCTREPORTER_CMD) 2> /dev/null)
+UNAME := $(shell command -v $(UNAME_CMD) 2> /dev/null)
+
+SYSTEM := $(shell $(UNAME) -s)
+ifeq ($(SYSTEM),Darwin)
+USER_FLAG = --user
+else
+USER_FLAG = 
+endif
 
 # Targets
 
@@ -108,8 +117,8 @@ check:
 
 # --- 
 
-pipinstall = @pip install $1 --user
-geminstall = @gem install $1 --user
+pipinstall = @pip install $1 $(USER_FLAG)
+geminstall = @gem install $1 $(USER_FLAG)
 
 install-deps: 
 	$(call checkfor,$(PYTHON2_CMD))
@@ -152,7 +161,7 @@ clean: check
 # --- 
 	
 build2: clean
-	$(PYTHON2) ./setup.py install --user --record $(INSTALLED_FILES_RECORD)
+	$(PYTHON2) ./setup.py install $(USER_FLAG) --record $(INSTALLED_FILES_RECORD)
 	
 # --- 
 	

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ machine:
 
 dependencies:
   override:
-    - gem install danger
-    - pip install tox tox-pyenv codeclimate-test-reporter
+    - make install-deps
     - pyenv local 2.7.10 3.5.0
 
 test:

--- a/pyconfig/version_info.py
+++ b/pyconfig/version_info.py
@@ -1,2 +1,2 @@
 remote_origin = 'git@github.com:samdmarshall/pyconfig.git'
-commit_hash = '1db9447'
+commit_hash = '14a6909'

--- a/pyconfig/version_info.py
+++ b/pyconfig/version_info.py
@@ -1,2 +1,2 @@
 remote_origin = 'git@github.com:samdmarshall/pyconfig.git'
-commit_hash = '14a6909'
+commit_hash = '15082aa'

--- a/pyconfig/version_info.py
+++ b/pyconfig/version_info.py
@@ -1,2 +1,2 @@
 remote_origin = 'git@github.com:samdmarshall/pyconfig.git'
-commit_hash = 'f8b86e8'
+commit_hash = '1db9447'


### PR DESCRIPTION
**Title**: Moving dependency installation into makefile rule

---

**Description**:
- CircleCI use to declare and install the dependencies necessary. These are being relocated to allow for more control and ease of setup anywhere.
  - 14a6909
- Updating makefile rules to accommodate installation on Linux vs OS X
  - 15082aa
- Updating makefile to remove the use of `echo` and to properly alias `exit`
  - 91980e2
