### PR TITLE
Restoring Danger to be run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ endif
 	
 # --- 
 
-ci: test lint report #danger
+ci: test lint report danger
 
 # ---
 

--- a/pyconfig/version_info.py
+++ b/pyconfig/version_info.py
@@ -1,2 +1,2 @@
 remote_origin = 'git@github.com:samdmarshall/pyconfig.git'
-commit_hash = 'd07fac2'
+commit_hash = '8c0e485'


### PR DESCRIPTION
**Description**: There currently seems to be a bug with Danger that causes it to run and consequently fail on CircleCI. This branch is to watch the status of Danger and see when it should be re-enabled.
