### PR TITLE
Update Dangerfile to 3.0

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -25,3 +25,6 @@
     'path'=> 'lint_output.txt'
   }
 ]
+
+# Run the shared Dangerfile with these settings
+danger.import_dangerfile "samdmarshall/danger"


### PR DESCRIPTION
**Moves the Dangerfile to support Danger 3.0 syntax**:

---

**Description**:

I removed the implicit `x/danger` lookup, and replaced  it with an API to define that you want to run another Dangerfile - https://github.com/danger/danger/pull/418

This should make everything work again.
