### PR TITLE
Fix a race condition in Serializer when directory already exists

### DIFF
--- a/pyconfig/Serializer/Serializer.py
+++ b/pyconfig/Serializer/Serializer.py
@@ -42,7 +42,12 @@ def openOutputFileToWrite(input_string):
     file_path = os.path.expanduser(input_string)
     parent_path = os.path.dirname(file_path)
     if not os.path.exists(parent_path):  # pragma: no cover
-        os.makedirs(parent_path)
+        try:
+            os.makedirs(parent_path)
+        except OSError as e:
+            if e.errno != 17:
+                raise
+            pass
     return open(file_path, 'w')
 
 def writeFile(config_node=None, scheme_name=None):


### PR DESCRIPTION
<!-- REQUIRED FIELDS -->
**Title**: Fix a race condition in Serializer when directory already exists.

---

**Description**:
We use pyconfig to generate the xcconfig files associated to our targets, which are about 40 (apps/frameworks/tests). Recently we parallelise the pyconfig execution and we notice that sometimes it fails with the following trace: 
```
Traceback (most recent call last):
169     File "/usr/local/Cellar/pyconfig/1.1.2/libexec/bin/pyconfig", line 9, in <module>
170       load_entry_point('pyconfig==1.1.2', 'console_scripts', 'pyconfig')()
171     File "/usr/local/Cellar/pyconfig/1.1.2/libexec/lib/python2.7/site-packages/pyconfig/main.py", line 157, in main
172       Serializer.writeFile(current_config, args.scheme)
173     File "/usr/local/Cellar/pyconfig/1.1.2/libexec/lib/python2.7/site-packages/pyconfig/Serializer/Serializer.py", line 67, in writeFile
174       output_file = openOutputFileToWrite(output_file_path)
175     File "/usr/local/Cellar/pyconfig/1.1.2/libexec/lib/python2.7/site-packages/pyconfig/Serializer/Serializer.py", line 45, in openOutputFileToWrite
176       os.makedirs(parent_path)
177     File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/os.py", line 157, in makedirs
178       mkdir(name, mode)
179   OSError: [Errno 17] File exists: '/Users/jenkins/Jenkins/workspace/ios-XING-monorepo-pull-requests/apps/XING/XING/Configurations'
```
Apparently there's a possible race condition in [Serializer.py](https://github.com/samdmarshall/pyconfig/blob/develop/pyconfig/Serializer/Serializer.py#L45) if the directory already exists (given that the output path for the pyconfig command is the same directory), so I added a check for this particular exception. 